### PR TITLE
[worker] Added worker which sends healthchecks

### DIFF
--- a/worker/src/pom.xml
+++ b/worker/src/pom.xml
@@ -24,9 +24,32 @@
       <version>1.7.5</version>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.16</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-jackson</artifactId>
       <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.27.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.18.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>service.health.check.messages</groupId>

--- a/worker/src/src/main/java/service/health/check/worker/AddressChecker.java
+++ b/worker/src/src/main/java/service/health/check/worker/AddressChecker.java
@@ -1,0 +1,42 @@
+package service.health.check.worker;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpHead;
+
+import lombok.extern.slf4j.Slf4j;
+import static org.apache.http.HttpStatus.SC_OK;
+import service.health.check.messages.AddressToCheck;
+import service.health.check.messages.CheckedAddress;
+import static service.health.check.worker.util.AddressCheckerUtil.extractURI;
+import static service.health.check.worker.util.AddressCheckerUtil.getRequestConfig;
+import static service.health.check.worker.util.AddressCheckerUtil.instantiateHttpClient;
+
+@Slf4j
+public class AddressChecker {
+
+    public CheckedAddress checkAddress(AddressToCheck addressToCheck) {
+        return new CheckedAddress(addressToCheck.getHost(), addressToCheck.getPort(),
+                                  isAddressHealthy(addressToCheck));
+    }
+
+    private boolean isAddressHealthy(AddressToCheck address) {
+        HttpClient httpClient = instantiateHttpClient();
+        try {
+            URI uri = extractURI(address);
+            HttpHead httpHead = new HttpHead(uri);
+            httpHead.setConfig(getRequestConfig());
+            HttpResponse execute = httpClient.execute(httpHead);
+            int statusCode = execute.getStatusLine().getStatusCode();
+            log.debug(String.valueOf(statusCode));
+            return statusCode == SC_OK;
+        } catch (IOException | URISyntaxException e) {
+            log.warn(e.getMessage(), e);
+        }
+        return false;
+    }
+}

--- a/worker/src/src/main/java/service/health/check/worker/App.java
+++ b/worker/src/src/main/java/service/health/check/worker/App.java
@@ -1,70 +1,34 @@
 package service.health.check.worker;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rabbitmq.client.AMQP;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Consumer;
-import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.MessageProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import service.health.check.messages.AddressToCheck;
-import service.health.check.messages.CheckedAddress;
+
+import lombok.extern.slf4j.Slf4j;
 import service.health.check.messages.Config;
-import java.util.Random;
 
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-
+@Slf4j
 public class App {
 
-	public App() {
-	}
+    public App() {
+    }
 
-	public static void main(String[] args)
-			throws IOException, TimeoutException {
-		Logger logger = LoggerFactory.getLogger(App.class);
-		ConnectionFactory factory = new ConnectionFactory();
-		Connection connection = factory.newConnection(Address.parseAddresses(
-				Config.RABBITMQ_CONNECTION_ADDRESS));
-		Channel channel = connection.createChannel();
+    public static void main(String[] args)
+            throws IOException, TimeoutException {
+        Connection queueConnection = getQueueConnection();
+        Channel channel = queueConnection.createChannel();
+        channel.queueDeclare(Config.ADDRESSES_TO_CHECK_QUEUE, true, false, false, null);
+        Consumer consumer = new CheckAddressMessageConsumer(channel);
+        channel.basicConsume(Config.ADDRESSES_TO_CHECK_QUEUE, true, consumer);
+    }
 
-		channel.queueDeclare(Config.ADDRESSES_TO_CHECK_QUEUE, true, false, false, null);
-
-		Consumer consumer = new DefaultConsumer(channel) {
-			@Override
-			public void handleDelivery(String consumerTag, Envelope envelope,
-					AMQP.BasicProperties properties, byte[] body)
-					throws IOException {
-				doWork(logger, channel, body);
-			}
-		};
-		channel.basicConsume(Config.ADDRESSES_TO_CHECK_QUEUE, true, consumer);
-	}
-
-	private static void doWork(Logger logger, Channel channel, byte[] body) throws IOException {
-		String messageJson = new String(body);
-		logger.info("Worker - Message received: " + messageJson);
-
-		final ObjectMapper mapper = new ObjectMapper();
-		AddressToCheck addressToCheck = mapper.readValue(messageJson,
-				new TypeReference<AddressToCheck>() {
-				});
-
-		Random rand = new Random();
-		CheckedAddress checkedAddress = new CheckedAddress(addressToCheck.getHost(), addressToCheck.getPort(), rand.nextInt(2) > 0);
-		channel.queueDeclare(Config.CHECKED_ADDRESSES_QUEUE, true, false, false, null);
-		String messageCheckAddressJson = mapper.writeValueAsString(checkedAddress);
-		channel.basicPublish("", Config.CHECKED_ADDRESSES_QUEUE, MessageProperties.PERSISTENT_TEXT_PLAIN, messageCheckAddressJson.getBytes());
-		logger.info("Worker - Message sent: " + messageCheckAddressJson);
-
-		logger.info("Worker - Work done! " + messageJson);
-	}
-
+    private static Connection getQueueConnection() throws IOException, TimeoutException {
+        ConnectionFactory factory = new ConnectionFactory();
+        return factory.newConnection(Address.parseAddresses(Config.RABBITMQ_CONNECTION_ADDRESS));
+    }
 }

--- a/worker/src/src/main/java/service/health/check/worker/CheckAddressMessageConsumer.java
+++ b/worker/src/src/main/java/service/health/check/worker/CheckAddressMessageConsumer.java
@@ -1,0 +1,54 @@
+package service.health.check.worker;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.MessageProperties;
+
+import lombok.extern.slf4j.Slf4j;
+import service.health.check.messages.AddressToCheck;
+import service.health.check.messages.CheckedAddress;
+import service.health.check.messages.Config;
+
+@Slf4j
+public class CheckAddressMessageConsumer extends DefaultConsumer {
+
+    // dependencies
+    private final AddressChecker addressChecker;
+    private final ObjectMapper mapper;
+
+    public CheckAddressMessageConsumer(Channel channel) {
+        super(channel);
+        this.addressChecker = new AddressChecker();
+        this.mapper = new ObjectMapper();
+    }
+
+    @Override
+    public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties,
+                               byte[] body) throws IOException {
+        String messageBody = new String(body);
+        AddressToCheck addressToCheck = extractAddress(messageBody);
+        CheckedAddress checkedAddress = addressChecker.checkAddress(addressToCheck);
+        returnCheckedAddressToQueue(checkedAddress);
+        log.info("Worker - Work done! " + messageBody);
+    }
+
+    private AddressToCheck extractAddress(String messageBody) throws JsonProcessingException {
+        log.info("Worker - Message received: " + messageBody);
+        return mapper.readValue(messageBody, AddressToCheck.class);
+    }
+
+    private void returnCheckedAddressToQueue(CheckedAddress checkedAddress)
+            throws IOException {
+        String messageCheckAddressJson = mapper.writeValueAsString(checkedAddress);
+        getChannel().queueDeclare(Config.CHECKED_ADDRESSES_QUEUE, true, false, false, null);
+        getChannel().basicPublish("", Config.CHECKED_ADDRESSES_QUEUE, MessageProperties.PERSISTENT_TEXT_PLAIN,
+                                  messageCheckAddressJson.getBytes());
+        log.info("Worker - Message sent: " + messageCheckAddressJson);
+    }
+}

--- a/worker/src/src/main/java/service/health/check/worker/util/AddressCheckerUtil.java
+++ b/worker/src/src/main/java/service/health/check/worker/util/AddressCheckerUtil.java
@@ -1,0 +1,53 @@
+package service.health.check.worker.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClients;
+
+import lombok.extern.slf4j.Slf4j;
+import service.health.check.messages.AddressToCheck;
+
+@Slf4j
+public class AddressCheckerUtil {
+
+    // constants
+    public static final int TIMEOUT = 1000;
+
+    public AddressCheckerUtil() {
+        throw new UnsupportedOperationException("Cannot instantiate Util class!");
+    }
+
+    public static RequestConfig getRequestConfig() {
+        return RequestConfig.custom()
+                            .setConnectTimeout(TIMEOUT)
+                            .setSocketTimeout(TIMEOUT)
+                            .setConnectionRequestTimeout(TIMEOUT)
+                            .build();
+    }
+
+    public static HttpClient instantiateHttpClient() {
+        return HttpClients.createDefault();
+    }
+
+    public static URI extractURI(AddressToCheck address) throws URISyntaxException {
+        URI uri = new URI(address.getHost());
+        Integer port = parsePort(address.getPort());
+        if (port == null) {
+            return uri;
+        }
+        return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), port, uri.getPath(),
+                       uri.getQuery(), uri.getFragment());
+    }
+
+    private static Integer parsePort(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException | NullPointerException e) {
+            log.warn("Port isn't int: " + value, e);
+            return null;
+        }
+    }
+}

--- a/worker/src/src/main/java/service/health/check/worker/util/AddressCheckerUtil.java
+++ b/worker/src/src/main/java/service/health/check/worker/util/AddressCheckerUtil.java
@@ -7,18 +7,17 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClients;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import service.health.check.messages.AddressToCheck;
 
 @Slf4j
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddressCheckerUtil {
 
     // constants
     public static final int TIMEOUT = 1000;
-
-    public AddressCheckerUtil() {
-        throw new UnsupportedOperationException("Cannot instantiate Util class!");
-    }
 
     public static RequestConfig getRequestConfig() {
         return RequestConfig.custom()
@@ -46,7 +45,7 @@ public class AddressCheckerUtil {
         try {
             return Integer.parseInt(value);
         } catch (NumberFormatException | NullPointerException e) {
-            log.warn("Port isn't int: " + value, e);
+            log.warn(String.format("Port isn't int: '%s'", value), e);
             return null;
         }
     }

--- a/worker/src/src/test/java/service/health/check/worker/AddressCheckerTest.java
+++ b/worker/src/src/test/java/service/health/check/worker/AddressCheckerTest.java
@@ -1,0 +1,89 @@
+package service.health.check.worker;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import service.health.check.messages.AddressToCheck;
+import service.health.check.messages.CheckedAddress;
+import service.health.check.worker.util.AddressCheckerUtil;
+
+public class AddressCheckerTest {
+
+    // constants
+    private static final Integer PORT = 8089;
+    private static final String PORT_TEXT = PORT.toString();
+    private static final String HOST = "http://localhost";
+
+    // dependencies
+    private AddressChecker addressChecker;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8089);
+
+    @Before
+    public void setup() {
+        this.addressChecker = new AddressChecker();
+    }
+
+    @Test
+    public void should_return_healthy_for_ok_response() {
+        // given
+        String path = "/request/ok";
+        String testUrl = HOST + path;
+        stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(SC_OK)));
+        AddressToCheck addressToCheck = new AddressToCheck(testUrl, PORT_TEXT);
+
+        // when
+        CheckedAddress checkedAddress = addressChecker.checkAddress(addressToCheck);
+
+        // then
+        assertThat(checkedAddress.getHost()).isEqualTo(testUrl);
+        assertThat(checkedAddress.getPort()).isEqualTo(PORT_TEXT);
+        assertThat(checkedAddress.getHealthy()).isTrue();
+    }
+
+    @Test
+    public void should_return_unhealthy_for_server_error() {
+        // given
+        String path = "/request/bad";
+        String testUrl = HOST + path;
+        stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(SC_INTERNAL_SERVER_ERROR)));
+        AddressToCheck addressToCheck = new AddressToCheck(testUrl, PORT_TEXT);
+
+        // when
+        CheckedAddress checkedAddress = addressChecker.checkAddress(addressToCheck);
+
+        // then
+        assertThat(checkedAddress.getHost()).isEqualTo(testUrl);
+        assertThat(checkedAddress.getPort()).isEqualTo(PORT_TEXT);
+        assertThat(checkedAddress.getHealthy()).isFalse();
+    }
+
+    @Test
+    public void should_return_unhealthy_for_timeout() {
+        // given
+        String path = "/request/timeout";
+        String testUrl = HOST + path;
+        stubFor(head(urlEqualTo(path))
+                        .willReturn(aResponse().withStatus(SC_OK).withFixedDelay(3 * AddressCheckerUtil.TIMEOUT)));
+        AddressToCheck addressToCheck = new AddressToCheck(testUrl, PORT_TEXT);
+
+        // when
+        CheckedAddress checkedAddress = addressChecker.checkAddress(addressToCheck);
+
+        // then
+        assertThat(checkedAddress.getHost()).isEqualTo(testUrl);
+        assertThat(checkedAddress.getPort()).isEqualTo(PORT_TEXT);
+        assertThat(checkedAddress.getHealthy()).isFalse();
+    }
+}


### PR DESCRIPTION
Modified worker so that it sends requests to given address instead of returning a random result.

The worker sends `HEAD` request to the given host on the given port. If no port is given or it isn't an integer, the default port for the scheme is used (it's set by `URI` constructor). Currently, the request has **1s** of timeout. 