### PR TITLE
Add GKE config for rabbit/worker/front

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -14,3 +14,10 @@ This project contains the automation that sets up the service stack in GCP.
 1. `./setup.sh` to setup the cluster
 1. `./push_images.sh` to build the application images and push them to the GCR
 1. `./deploy.sh` to create kubernetes jobs/services to run the app
+
+# How to test it?
+1. Open a proxy to the frontend: `kubectl port-forward deployment/front 7000:8090`
+  (this might not be needed if we set-up proper ingress, but it's not done yet)
+1. `curl -d '{"host":"https://www.google.com/","port":"80", "healthy":"true"}' -H 'Content-Type: application/json' http://localhost:7000/addresses`
+1. Check logs of the worker (you should be able to see logs each second for the health checks).
+  This shows that frontend/postgres/server/rabbit/worker are integrated properly end to end.

--- a/cloud/deploy.sh
+++ b/cloud/deploy.sh
@@ -7,6 +7,10 @@ do
 done
 
 kubectl apply -f postgres.yaml
+kubectl apply -f rabbit.yaml
 sleep 10s
 kubectl apply -f database-schema.yaml
+sleep 10s
+kubectl apply -f worker.yaml
 kubectl apply -f server.yaml
+kubectl apply -f front.yaml

--- a/cloud/front.yaml.template
+++ b/cloud/front.yaml.template
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: front
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: front
+  template:
+    metadata:
+      labels:
+        app: front
+    spec:
+      containers:
+          - name: worker
+            image: gcr.io/PROJECT_NAME/front
+            command: ["/app/start.sh"]
+            imagePullPolicy: Always
+            ports:
+              - containerPort: 8090
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: front
+spec:
+  selector:
+    app: front
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 8090
+      targetPort: 8090

--- a/cloud/push_images.sh
+++ b/cloud/push_images.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # extend app list when more apps are supported
-for app in server database-schema
+for app in server database-schema worker front
 do
 (
   cd ../"$app"

--- a/cloud/rabbit.yaml
+++ b/cloud/rabbit.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbit
+  template:
+    metadata:
+      labels:
+        app: rabbit
+    spec:
+      containers:
+        - name: rabbit
+          image: rabbitmq:3-management-alpine
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbit
+  ports:
+    - protocol: TCP
+      port: 5672
+      targetPort: 5672
+

--- a/cloud/worker.yaml.template
+++ b/cloud/worker.yaml.template
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+          - name: worker
+            image: gcr.io/PROJECT_NAME/worker
+            command: ["/app/start.sh"]
+            imagePullPolicy: Always


### PR DESCRIPTION
This allows full e2e testing of health checks.
Notification mechanism is still to be done.

Testing:
* ran deployments, verified the worker logs to see that health checks are being executed